### PR TITLE
Fix for Go 1.14

### DIFF
--- a/generator/templates/schematype.gotmpl
+++ b/generator/templates/schematype.gotmpl
@@ -1,5 +1,5 @@
 {{ define "schemaType" }}
-  {{- if and (or ((len .AllOf) gt 0) .IsAnonymous) ( not .IsMap) }}
+  {{- if and (or (gt (len .AllOf) 0) .IsAnonymous) ( not .IsMap) }}
     {{- template "schemaBody" . }}
   {{- else }}
     {{- if and (not .IsMap) .IsNullable }}*{{ end }}


### PR DESCRIPTION
This minor change has been fixed in upstream's commit go-swagger/go-swagger@7abb5d0a458166e73c4b81682cf8ba62ad1451a4, however this is a much bigger change which can't easily be cherry picked. I'm merging this change into the golang-1.13-fix branch because that's what appears to be used by Moby, but it may be worth the time to get us back to using the upstream repo if possible.

The Go CL that's causing this to create warnings now is: https://golang.org/cl/206124

See also https://github.com/moby/moby/pull/40353/#issuecomment-585943746

/cc @thaJeztah